### PR TITLE
Strip down README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+sampjs
+======
+
+sampjs is a JavaScript library for the SAMP Web Profile.
+For more discussion of what that means, and pointers to how you might
+use it, see the [documentation](http://astrojs.github.com/sampjs/).
+


### PR DESCRIPTION
Content of README.md is now mostly moved into gh-pages, which has proper documentation.
