### PR TITLE
Expose Connection class

### DIFF
--- a/samp.js
+++ b/samp.js
@@ -1299,6 +1299,7 @@ var samp = (function() {
     jss.ping = ping;
     jss.isSubscribed = isSubscribed;
     jss.Connector = Connector;
+    jss.Connection = Connection;
     jss.CallableClient = CallableClient;
     jss.ClientTracker = ClientTracker;
 


### PR DESCRIPTION
How about to make public Connection class? The reason is need to reconstruct connection from private-key, and do not confirm it every time site page reloaded.
