### PR TITLE
Package sampjs with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sampjs",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "sampjs is a small JavaScript library for using the SAMP Web Profile from within web pages.",
   "main": "samp.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "sampjs",
+  "version": "1.0.0",
+  "description": "sampjs is a small JavaScript library for using the SAMP Web Profile from within web pages.",
+  "main": "samp.js",
+  "directories": {
+    "example": "examples"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/astrojs/sampjs"
+  },
+  "keywords": [
+    "samp",
+    "sampjs",
+    "ivoa"
+  ],
+  "author": {
+    "name": "Mark Taylor",
+    "email": "m.b.taylor@bristol.ac.uk",
+    "url": "https://www.star.bristol.ac.uk/~mbt/"
+  },
+  "contributors": [
+    {
+      "name": "Daniel Garcia Briseno",
+      "email": "dgarciabriseno@sesda.com"
+    }
+  ],
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/astrojs/sampjs/issues"
+  },
+  "homepage": "https://github.com/astrojs/sampjs#readme"
+}

--- a/samp.js
+++ b/samp.js
@@ -89,7 +89,7 @@ var samp = (function() {
         var child;
         for (i = 0; i < el.childNodes.length; i++ ) {
             child = el.childNodes[i];
-            if (child.nodeType === 1) {           // Element 
+            if (child.nodeType === 1) {           // Element
                 throw new Error("Element found in text content");
             }
             else if (child.nodeType === 3 ||      // Text
@@ -143,7 +143,7 @@ var samp = (function() {
             ok = ok && typeList[i] === actualTypeList[i];
         }
         if (!ok) {
-            throw new Error("Param type list mismatch: " 
+            throw new Error("Param type list mismatch: "
                           + "[" + typeList + "] != "
                           + "[" + actualTypeList + "]");
         }
@@ -174,7 +174,7 @@ var samp = (function() {
             result.push(prefix + "    </data>",
                         prefix + "  </array>",
                         prefix + "</value>");
-          
+
             return result.join("\n");
         }
         else if (type === TYPE_MAP) {
@@ -741,7 +741,7 @@ var samp = (function() {
     //     receiveNotification(string sender-id, map message)
     //     receiveCall(string sender-id, string msg-id, map message)
     //     receiveResponse(string responder-id, string msg-tag, map response)
-    // 
+    //
     // The successHandler argument will be called with no arguments if the
     // allowCallbacks hub method completes successfully - it is a suitable
     // hook to use for declaring subscriptions.
@@ -1317,3 +1317,5 @@ var samp = (function() {
 
     return jss;
 })();
+
+module.exports = { samp }


### PR DESCRIPTION
Hi, I'm using sampjs in a project to send info to [JHelioviewer](https://github.com/Helioviewer-Project/JHelioviewer-SWHV/)

Here I've packaged it into an npm package so it can be installed into projects with `npm install sampjs`.
This is a more modern way to distribute javascript packages.

I published the package already https://www.npmjs.com/package/sampjs
I messed up the version numbers so it's stuck starting at 1.0.2.

I can transfer ownership to you on the registry if you want it. It's easy to publish new versions after making changes. Just make changes, update the version number, and then run `npm publish`